### PR TITLE
Updated limonp

### DIFF
--- a/deps/limonp/LocalVector.hpp
+++ b/deps/limonp/LocalVector.hpp
@@ -55,12 +55,12 @@ class LocalVector {
     size_ = vec.size();
     capacity_ = vec.capacity();
     if(vec.buffer_ == vec.ptr_) {
-      memcpy(buffer_, vec.buffer_, sizeof(T) * size_);
+      memcpy(static_cast<void*>(buffer_), vec.buffer_, sizeof(T) * size_);
       ptr_ = buffer_;
     } else {
       ptr_ = (T*) malloc(vec.capacity() * sizeof(T));
       assert(ptr_);
-      memcpy(ptr_, vec.ptr_, vec.size() * sizeof(T));
+      memcpy(static_cast<void*>(ptr_), vec.ptr_, vec.size() * sizeof(T));
     }
     return *this;
   }
@@ -92,7 +92,7 @@ class LocalVector {
     assert(next);
     T * old = ptr_;
     ptr_ = next;
-    memcpy(ptr_, old, sizeof(T) * capacity_);
+    memcpy(static_cast<void*>(ptr_), old, sizeof(T) * capacity_);
     capacity_ = size;
     if(old != buffer_) {
       free(old);

--- a/deps/limonp/StdExtension.hpp
+++ b/deps/limonp/StdExtension.hpp
@@ -6,7 +6,7 @@
 #ifdef __APPLE__
 #include <unordered_map>
 #include <unordered_set>
-#elif(__cplusplus == 201103L)
+#elif(__cplusplus >= 201103L)
 #include <unordered_map>
 #include <unordered_set>
 #elif defined _MSC_VER
@@ -29,12 +29,23 @@ using std::tr1::unordered_set;
 #include <fstream>
 #include <sstream>
 
-#define print(x) std::cout << x << std::endl
-
 namespace std {
 
 template<typename T>
 ostream& operator << (ostream& os, const vector<T>& v) {
+  if(v.empty()) {
+    return os << "[]";
+  }
+  os<<"["<<v[0];
+  for(size_t i = 1; i < v.size(); i++) {
+    os<<", "<<v[i];
+  }
+  os<<"]";
+  return os;
+}
+
+template<>
+inline ostream& operator << (ostream& os, const vector<string>& v) {
   if(v.empty()) {
     return os << "[]";
   }

--- a/deps/limonp/StringUtil.hpp
+++ b/deps/limonp/StringUtil.hpp
@@ -80,7 +80,7 @@ inline string& Lower(string& str) {
 
 inline bool IsSpace(unsigned c) {
   // when passing large int as the argument of isspace, it core dump, so here need a type cast.
-  return c > 0xff ? false : std::isspace(c & 0xff);
+  return c > 0xff ? false : std::isspace(c & 0xff) != 0;
 }
 
 inline std::string& LTrim(std::string &s) {


### PR DESCRIPTION
The current build relies on an outdated version of limonp, which fails to build on compilers nowadays.

```
g++ -o jieba.o -c -DLOGGING_LEVEL=LL_WARNING -I./deps/ lib/jieba.cpp
In file included from ./deps/limonp/StringUtil.hpp:24,
                 from ./deps/cppjieba/DictTrie.hpp:11,
                 from ./deps/cppjieba/QuerySegment.hpp:8,
                 from ./deps/cppjieba/Jieba.hpp:4,
                 from lib/jieba.cpp:5:
./deps/limonp/StdExtension.hpp:19:17: error: ‘template<class _Key, class _Tp, class _Hash, class _Pred, class _Alloc> class std::tr1::unordered_map’ conflicts with a previous declaration
   19 | using std::tr1::unordered_map;
      |                 ^~~~~~~~~~~~~
```

This pull request just polls from [limonp](https://github.com/yanyiwu/limonp) and updates it to [v0.6.4](https://github.com/yanyiwu/limonp/commit/6da226bf282ebf5e8dd1220a7f5b8512dfc4fd11).